### PR TITLE
Fix recommendation to avoid eviction with Redis

### DIFF
--- a/docs/getting-started/brokers/redis.rst
+++ b/docs/getting-started/brokers/redis.rst
@@ -143,7 +143,13 @@ If you experience an error like:
     removed from the Redis database.
 
 then you may want to configure the :command:`redis-server` to not evict keys
-by setting the ``timeout`` parameter to 0 in the redis configuration file.
+by setting in the redis configuration file:
+* the ``maxmemory`` option
+* the ``maxmemory-policy`` option to ``noeviction`` or ``allkeys-lru``
+
+See Redis server documentation about Eviction Policies for details:
+    
+    https://redis.io/topics/lru-cache
 
 Group result ordering
 ---------------------


### PR DESCRIPTION
## Description

This updates the documentation about Redis key eviction to point the reader towards the right Redis server settings.

The documentation was pointing at the `timeout` setting which is related to server-client connection timeout and
unrelated to eviction.

Eviction is a complex problem with Redis which can have various consequences when used with Celery, and different ones whether it's used as a broker or results backend, or both. So this update:
* Suggests default settings that should work in most simple cases
* Points at the Redis documentation so the reader has a starting point to understand the underlying logic and make the right choices for their own use-case.
